### PR TITLE
Change IRC icon

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -27,7 +27,7 @@
       <span class="pull-right">
         <a href="https://groups.google.com/forum/?fromgroups#!forum/kaos-general" target="blank"><i class="fa fa-envelope fa-lg"></i></a>
         <a href="https://github.com/KaOSx" target="blank"><i class="fa fa-github fa-lg"></i></a>
-        <a href="https://web.libera.chat/#KaOS" target="blank"><i class="fa fa-wechat fa-lg"></i></a>
+        <a href="https://web.libera.chat/#KaOS" target="blank"><i class="fa fa-comments fa-lg"></i></a>
         <a href="https://www.transifex.com/organization/kaos/dashboard/kaos" target="blank"><i class="fa fa-language fa-lg"></i></a>
         <a href="https://gitter.im/KaOSx/KaOS/" target="blank"><i class="fa fa-tasks fa-lg"></i></a>
         <a href="{{ site.baseurl }}/feed.xml" target="blank"><i class="fa fa-rss fa-lg" title="RSS feed"></i></a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
 <div class="social_header">
     <a href="https://groups.google.com/forum/?fromgroups#!forum/kaos-general" target="blank"><i class="fa fa-envelope" title="Google Groups"></i></a>
     <a href="https://github.com/KaOSx" target="blank"><i class="fa fa-github" title="Github"></i></a>
-    <a href="https://web.libera.chat/#KaOS" target="blank"><i class="fa fa-wechat" title="IRC"></i></a>
+    <a href="https://web.libera.chat/#KaOS" target="blank"><i class="fa fa-comments" title="IRC"></i></a>
     <a href="https://www.transifex.com/organization/kaos/dashboard/kaos" target="blank"><i class="fa fa-language" title="Transifex"></i></a>
     <a href="https://gitter.im/KaOSx/KaOS/" target="blank"><i class="fa fa-tasks" title="Gitter"></i></a>
     <a href="{{ site.baseurl }}/feed.xml" target="blank"><i class="fa fa-rss" title="RSS feed"></i></a>


### PR DESCRIPTION
The WeChat icon is very misleading and it's not clear that it represents general chatting (or IRC) instead of a specific platform (WeChat).